### PR TITLE
Fix streaming CSV export

### DIFF
--- a/features/step_definitions/format_steps.rb
+++ b/features/step_definitions/format_steps.rb
@@ -24,11 +24,13 @@ end
 # Check first rows of the displayed CSV.
 Then /^I should download a CSV file with "([^"]*)" separator for "([^"]*)" containing:$/ do |sep, resource_name, table|
   body   = page.driver.response.body
-  content_type_header, content_disposition_header = %w[Content-Type Content-Disposition].map do |header_name|
+  content_type_header, content_disposition_header, last_modified_header = %w[Content-Type Content-Disposition Last-Modified].map do |header_name|
     page.response_headers[header_name]
   end
   expect(content_type_header).to eq 'text/csv; charset=utf-8'
   expect(content_disposition_header).to match /\Aattachment; filename=".+?\.csv"\z/
+  expect(last_modified_header).to_not be_nil
+  expect(Date.strptime(last_modified_header, "%a, %d %b %Y %H:%M:%S GMT")).to be_a(Date)
 
   csv = CSV.parse(body, col_sep: sep)
   table.raw.each_with_index do |expected_row, row_index|

--- a/lib/active_admin/resource_controller/streaming.rb
+++ b/lib/active_admin/resource_controller/streaming.rb
@@ -20,6 +20,7 @@ module ActiveAdmin
       def stream_resource(&block)
         headers['X-Accel-Buffering'] = 'no'
         headers['Cache-Control'] = 'no-cache'
+        headers["Last-Modified"] = Time.current.httpdate
 
         if ActiveAdmin.application.disable_streaming_in.include? Rails.env
           self.response_body = block[String.new]


### PR DESCRIPTION
Streaming was not working either in development (disable_streaming off) nor on production Heroku. Adding a Last-Modified header made it work.

The problem would only manifest when using rack 2.2 or higher, and was caused by rack/rack#1416, where the `Rack::ETag`
middleware changed it's behaviour to buffer the response and calculate an ETag digest even though the `Cache-Control: no-cache` header is set. This breaks the CSV streaming responses so to avoid that we use the hack outlined in rack/rack#1619 and set a Last-Modified header which triggers the `skip_caching?` condition in the `Rack::ETag` middleware.

See activeadmin/activeadmin#6451 and alphagov/e-petitions@46413a7